### PR TITLE
Use stack clean when building.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -100,6 +100,7 @@ if [ -f "$BUILD_DIR/Makefile" ]; then
     make install
 else
     stack setup
+    stack clean
     stack build --copy-bins
 fi
 


### PR DESCRIPTION
The current version of stack is unable to [detect changes in
hamlet](https://github.com/yesodweb/yesod/issues/1551).

This updates the buildpack to always clean out the old build, so even
though the change to hamlet files is not detected, they will be rebuilt
anyway.

The issue with stack [should be
fixed](https://github.com/commercialhaskell/stack/blob/aae15e3ae5767febe9fcad36bf5a5e184c635de1/ChangeLog.md)
in the next release.